### PR TITLE
Fix issue when running collaborator payloads

### DIFF
--- a/src/nb/freddy/intruder/RCEPayloadGenerator.java
+++ b/src/nb/freddy/intruder/RCEPayloadGenerator.java
@@ -8,6 +8,7 @@
 
 package nb.freddy.intruder;
 
+import burp.IBurpCollaboratorClientContext;
 import burp.IIntruderAttack;
 import burp.IIntruderPayloadGenerator;
 import nb.freddy.modules.FreddyModuleBase;
@@ -41,13 +42,14 @@ public class RCEPayloadGenerator implements IIntruderPayloadGenerator {
      *
      * @param modules A list of loaded Freddy modules.
      ******************/
-    public RCEPayloadGenerator(ArrayList<FreddyModuleBase> modules, IIntruderAttack attack) {
+    public RCEPayloadGenerator(ArrayList<FreddyModuleBase> modules, IIntruderAttack attack, IBurpCollaboratorClientContext collabContext) {
         List<Payload> modPayloads;
 
         //Generate a list of all RCE detection payloads
         _payloads = new ArrayList<>();
+
         for (FreddyModuleBase module : modules) {
-            modPayloads = module.getRCEPayloads(attack);
+            modPayloads = module.getRCEPayloads(attack,collabContext);
             if (modPayloads != null) {
                 _payloads.addAll(modPayloads);
             }

--- a/src/nb/freddy/intruder/RCEPayloadGeneratorFactory.java
+++ b/src/nb/freddy/intruder/RCEPayloadGeneratorFactory.java
@@ -8,6 +8,7 @@
 
 package nb.freddy.intruder;
 
+import burp.IBurpCollaboratorClientContext;
 import burp.IIntruderAttack;
 import burp.IIntruderPayloadGenerator;
 import burp.IIntruderPayloadGeneratorFactory;
@@ -29,14 +30,15 @@ public class RCEPayloadGeneratorFactory implements IIntruderPayloadGeneratorFact
      * Properties
      ******************/
     private final ArrayList<FreddyModuleBase> _modules;
-
+    private final IBurpCollaboratorClientContext _collabContext;
     /*******************
      * Initialise the payload generator factory.
      *
      * @param modules A list of loaded Freddy modules to retrieve payloads from.
      ******************/
-    public RCEPayloadGeneratorFactory(ArrayList<FreddyModuleBase> modules) {
+    public RCEPayloadGeneratorFactory(ArrayList<FreddyModuleBase> modules, IBurpCollaboratorClientContext collabContext) {
         _modules = modules;
+        _collabContext = collabContext;
     }
 
     /*******************
@@ -55,6 +57,6 @@ public class RCEPayloadGeneratorFactory implements IIntruderPayloadGeneratorFact
      * @return An instance of ErrorPayloadGenerator.
      ******************/
     public IIntruderPayloadGenerator createNewInstance(IIntruderAttack attack) {
-        return new RCEPayloadGenerator(_modules, attack);
+        return new RCEPayloadGenerator(_modules, attack,_collabContext);
     }
 }

--- a/src/nb/freddy/modules/CollaboratorRecord.java
+++ b/src/nb/freddy/modules/CollaboratorRecord.java
@@ -54,6 +54,8 @@ class CollaboratorRecord {
         timeStamp = System.currentTimeMillis();
     }
 
+
+
     /*******************
      * Getters
      ******************/

--- a/src/nb/freddy/modules/FreddyModuleBase.java
+++ b/src/nb/freddy/modules/FreddyModuleBase.java
@@ -865,11 +865,13 @@ public abstract class FreddyModuleBase {
         //Issue collaborator-based payloads
         if (_rceCapable) {
 //            TODO SB generate new collabContext
-            _collabContext = null;
+            if( _collabContext  == null){
             try {
+                _callbacks.printOutput( "Create context" );
                 _collabContext = _callbacks.createBurpCollaboratorClientContext();
             } catch(IllegalStateException ex) {
                 Log.warn("Collaborator is explicitly disabled, stopping");
+            }
             }
             if( _collabContext  != null) {
                 for (CollaboratorPayload p : _collaboratorPayloads) {
@@ -928,10 +930,14 @@ public abstract class FreddyModuleBase {
      ******************/
     public boolean handleCollaboratorInteraction(IBurpCollaboratorInteraction interaction) {
         String interactionId = interaction.getProperty("interaction_id");
+
+
         boolean result = false;
         Iterator<CollaboratorRecord> iterator = _collabRecords.iterator();
         while (iterator.hasNext()) {
+
             CollaboratorRecord record = iterator.next();
+
             if (record.getCollaboratorId().equals(interactionId)) {
                 try {
                     _callbacks.addScanIssue(createCollaboratorIssue(record, interaction));
@@ -1044,7 +1050,6 @@ public abstract class FreddyModuleBase {
     private IScanIssue createActiveScanExceptionBasedIssue(IHttpRequestResponse baseReqRes, IHttpRequestResponse newReqRes, List<int[]> reqMarkers, List<int[]> resMarkers) {
         String issueDescription;
         String issueRemediation;
-
         //Generate the issue description string
         issueDescription = "A payload was inserted into the HTTP request that would trigger a specific " +
                 "exception if it were deserialized by the <strong>" + _targetName + "</strong> library/API. " +
@@ -1199,10 +1204,10 @@ public abstract class FreddyModuleBase {
         return _exceptionBasedPayloads;
     }
 
-    public ArrayList<Payload> getRCEPayloads(IIntruderAttack attack) {
+    public ArrayList<Payload> getRCEPayloads(IIntruderAttack attack,IBurpCollaboratorClientContext collabContext) {
+        this._collabContext= collabContext;
         ArrayList<Payload> result = new ArrayList<>();
         try {
-            _collabContext = _callbacks.createBurpCollaboratorClientContext();
 
             String collabId = _collabContext.generatePayload(false);
             String host = _collabContext.getCollaboratorServerLocation();
@@ -1221,6 +1226,7 @@ public abstract class FreddyModuleBase {
                 }
                 result.add(p);
             }
+
         } catch (IllegalStateException ex) {
             Log.warn("Burpsuite Collaborator is explicitly disabled, returning empty array");
         }


### PR DESCRIPTION
This pull request includes the following fixes : 

1. Two different _collabContext are created when running a scan, one for the scanner and one FreddyCollaboratorThread.start() which meant no issues generated as the collabContext check by handleCollaboratorInteraction is always empty
2. Added context to intruder (getRCEPayloads) to be able to identify interaction through handleCollaboratorInteraction 
3. Added some output to confirm interaction on burp extension output

I'm not very familiar with java you might find the code a bit messy i tried to make it work 